### PR TITLE
`convertIsbn()`で予期してない（=不正な）値が返ってくるバグの修正

### DIFF
--- a/src/isbn2/isbn.ts
+++ b/src/isbn2/isbn.ts
@@ -30,8 +30,9 @@ export function convertIsbn(isbn: string): string | null {
       let n = Number(c);
       return tmp + n * (10 - i);
     }, 0);
-    const checkDigit = 11 - (sum % 11);
-    const isbn10 = isbn.substring(3, 12) + String(checkDigit);
+    const checkDigit = (11 - (sum % 11)) % 11;
+    const checkDigitStr = checkDigit === 10 ? "X" : String(checkDigit);
+    const isbn10 = isbn.substring(3, 12) + checkDigitStr;
     return isbn10;
   } else if (isbn.length == 10) {
     let q = "978" + isbn;


### PR DESCRIPTION
`convertIsbn()`で予期した値が返ってこないことがあったので修正しました

👇 修正前テスト結果

```
convertAsin2Isbn13 test1 : 4596708460 -> 9784596708465
 : true
convertAsin2Isbn13 test2 : 4799215663 -> 9784799215661
 : true
convertAsin2Isbn13 test3-kindle : B09MYHB3X3 -> ERR_KINDLE
 : false
error => KINDLE
convertUrl2Asin test-url : https://www.amazon.co.jp/dp/4799215663/ref=cm_sw_r_tw_dp_5XW9TEXBPTC54CE90CE9 -> 4799215663
 : true
{ isbn: '9784799215661', error: '' }
{ isbn: '', error: 'FORMAT' }
4799215663
https://www.amazon.co.jp/dp/4799215663
```

👇 修正後テスト結果

```
convertAsin2Isbn13 test1 : 4596708460 -> 9784596708465
 : true
convertAsin2Isbn13 test2 : 4799215663 -> 9784799215661
 : true
convertAsin2Isbn13 test3-kindle : B09MYHB3X3 -> ERR_KINDLE
 : false
error => KINDLE
convertUrl2Asin test-url : https://www.amazon.co.jp/dp/4799215663/ref=cm_sw_r_tw_dp_5XW9TEXBPTC54CE90CE9 -> 4799215663
 : true
{ isbn: '9784799215661', error: '' }
{ isbn: '', error: 'FORMAT' }
4799215663
https://www.amazon.co.jp/dp/4799215663
```

## 関数の返り値の変更

### BEFORE
```ts
convertIsbn("9784309226712")
// expected(correct): 430922671X
// received: 43092267110

convertIsbn("9784534059628")
// expected(correct): 4534059620
// received: 45340596211
```

### AFTER
```ts
convertIsbn("9784309226712") // => 430922671X
convertIsbn("9784534059628") // => 4534059620
```